### PR TITLE
Update XDomain to version 6.17 from 6.15. It handles xhr errors better s...

### DIFF
--- a/lib/xdomain_rails/version.rb
+++ b/lib/xdomain_rails/version.rb
@@ -1,3 +1,3 @@
 module XdomainRails
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/vendor/assets/javascripts/xdomain.js
+++ b/vendor/assets/javascripts/xdomain.js
@@ -1,8 +1,10 @@
-// XDomain - v0.6.15 - https://github.com/jpillora/xdomain
+// XDomain - v0.6.17 - https://github.com/jpillora/xdomain
 // Jaime Pillora <dev@jpillora.com> - MIT Copyright 2014
-(function(window,undefined) {// XHook - v1.2.4 - https://github.com/jpillora/xhook
+(function(window,undefined) {
+// XHook - v1.3.0 - https://github.com/jpillora/xhook
 // Jaime Pillora <dev@jpillora.com> - MIT Copyright 2014
-(function(window,undefined) {var AFTER, BEFORE, COMMON_EVENTS, EventEmitter, FIRE, FormData, NativeFormData, OFF, ON, READY_STATE, UPLOAD_EVENTS, XHookHttpRequest, XMLHTTP, convertHeaders, document, fakeEvent, mergeObjects, proxyEvents, slice, xhook, _base,
+(function(window,undefined) {
+var AFTER, BEFORE, COMMON_EVENTS, EventEmitter, FIRE, FormData, NativeFormData, OFF, ON, READY_STATE, UPLOAD_EVENTS, XHookHttpRequest, XMLHTTP, convertHeaders, deprecatedProp, document, fakeEvent, mergeObjects, msie, proxyEvents, slice, xhook, _base,
   __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 document = window.document;
@@ -27,6 +29,12 @@ UPLOAD_EVENTS = ['load', 'loadend', 'loadstart'];
 
 COMMON_EVENTS = ['progress', 'abort', 'error', 'timeout'];
 
+msie = parseInt((/msie (\d+)/.exec(navigator.userAgent.toLowerCase()) || [])[1]);
+
+if (isNaN(msie)) {
+  msie = parseInt((/trident\/.*; rv:(\d+)/.exec(navigator.userAgent.toLowerCase()) || [])[1]);
+}
+
 (_base = Array.prototype).indexOf || (_base.indexOf = function(item) {
   var i, x, _i, _len;
   for (i = _i = 0, _len = this.length; _i < _len; i = ++_i) {
@@ -42,11 +50,15 @@ slice = function(o, n) {
   return Array.prototype.slice.call(o, n);
 };
 
+deprecatedProp = function(p) {
+  return p === "returnValue" || p === "totalSize" || p === "position";
+};
+
 mergeObjects = function(src, dst) {
   var k, v;
   for (k in src) {
     v = src[k];
-    if (k === "returnValue") {
+    if (deprecatedProp(k)) {
       continue;
     }
     try {
@@ -63,7 +75,7 @@ proxyEvents = function(events, src, dst) {
       var clone, k, val;
       clone = {};
       for (k in e) {
-        if (k === "returnValue") {
+        if (deprecatedProp(k)) {
           continue;
         }
         val = e[k];
@@ -113,6 +125,13 @@ EventEmitter = function(nodeStyle) {
   };
   emitter[OFF] = function(event, callback) {
     var i;
+    if (event === undefined) {
+      events = {};
+      return;
+    }
+    if (callback === undefined) {
+      events[event] = [];
+    }
     i = listeners(event).indexOf(callback);
     if (i === -1) {
       return;
@@ -249,49 +268,56 @@ if (NativeFormData) {
 xhook[XMLHTTP] = window[XMLHTTP];
 
 XHookHttpRequest = window[XMLHTTP] = function() {
-  var currentState, emitFinal, emitReadyState, facade, hasError, hasErrorHandler, readBody, readHead, request, response, setReadyState, transiting, writeBody, writeHead, xhr;
+  var ABORTED, currentState, emitFinal, emitReadyState, facade, hasError, hasErrorHandler, readBody, readHead, request, response, setReadyState, status, transiting, writeBody, writeHead, xhr;
+  ABORTED = -1;
   xhr = new xhook[XMLHTTP]();
-  hasError = false;
-  transiting = false;
   request = {};
-  request.headers = {};
-  request.headerNames = {};
-  response = {};
-  response.headers = {};
+  status = null;
+  hasError = void 0;
+  transiting = void 0;
+  response = void 0;
   readHead = function() {
     var key, name, val, _ref;
-    response.status = xhr.status;
-    response.statusText = xhr.statusText;
-    _ref = convertHeaders(xhr.getAllResponseHeaders());
-    for (key in _ref) {
-      val = _ref[key];
-      if (!response.headers[key]) {
-        name = key.toLowerCase();
-        response.headers[name] = val;
+    response.status = status || xhr.status;
+    if (!(status === ABORTED && msie < 10)) {
+      response.statusText = xhr.statusText;
+    }
+    if (status !== ABORTED) {
+      _ref = convertHeaders(xhr.getAllResponseHeaders());
+      for (key in _ref) {
+        val = _ref[key];
+        if (!response.headers[key]) {
+          name = key.toLowerCase();
+          response.headers[name] = val;
+        }
       }
     }
   };
   readBody = function() {
-    try {
+    if ('responseText' in xhr) {
       response.text = xhr.responseText;
-    } catch (_error) {}
-    try {
+    }
+    if ('responseXML' in xhr) {
       response.xml = xhr.responseXML;
-    } catch (_error) {}
-    response.data = xhr.response || response.text;
+    }
+    if ('response' in xhr) {
+      response.data = xhr.response;
+    }
   };
   writeHead = function() {
     facade.status = response.status;
     facade.statusText = response.statusText;
   };
   writeBody = function() {
-    if (response.hasOwnProperty('text')) {
+    if ('text' in response) {
       facade.responseText = response.text;
     }
-    if (response.hasOwnProperty('xml')) {
+    if ('xml' in response) {
       facade.responseXML = response.xml;
     }
-    facade.response = response.data || null;
+    if ('data' in response) {
+      facade.response = response.data;
+    }
   };
   emitReadyState = function(n) {
     while (n > currentState && currentState < 4) {
@@ -379,6 +405,14 @@ XHookHttpRequest = window[XMLHTTP] = function() {
   }
   facade.status = 0;
   facade.open = function(method, url, async, user, pass) {
+    currentState = 0;
+    hasError = false;
+    transiting = false;
+    request.headers = {};
+    request.headerNames = {};
+    request.status = 0;
+    response = {};
+    response.headers = {};
     request.method = method;
     request.url = url;
     request.async = async !== false;
@@ -456,6 +490,7 @@ XHookHttpRequest = window[XMLHTTP] = function() {
     process();
   };
   facade.abort = function() {
+    status = ABORTED;
     if (transiting) {
       xhr.abort();
     } else {
@@ -498,8 +533,9 @@ if (typeof this.define === "function" && this.define.amd) {
 } else {
   (this.exports || this).xhook = xhook;
 }
+
 }.call(this,window));
-var CHECK_INTERVAL, COMPAT_VERSION, XD_CHECK, addMasters, addSlaves, connect, console, createSocket, currentOrigin, document, feature, frames, getFrame, guid, handler, initMaster, initSlave, instOf, jsonEncode, listen, location, log, logger, masters, onMessage, parseUrl, slaves, slice, sockets, startPostMessage, strip, toRegExp, warn, xdomain, xhook, _i, _len, _ref;
+var CHECK_INTERVAL, COMPAT_VERSION, XD_CHECK, addMasters, addSlaves, connect, console, createSocket, currentOrigin, document, emitter, feature, frames, getFrame, guid, handler, initMaster, initSlave, instOf, jsonEncode, listen, location, log, logger, masters, onMessage, parseUrl, setupEmitter, slaves, slice, sockets, startPostMessage, strip, toRegExp, warn, xdomain, xhook, _i, _len, _ref;
 
 slaves = null;
 
@@ -606,7 +642,9 @@ initMaster = function() {
     }
     send();
   };
-  xhook.addWithCredentials = true;
+  if (!('addWithCredentials' in xhook)) {
+    xhook.addWithCredentials = true;
+  }
   return xhook.before(function(request, callback) {
     var frame, p, socket;
     p = parseUrl(request.url);
@@ -864,8 +902,10 @@ createSocket = function(id, frame) {
       if (ready) {
         return;
       }
-      if (checks++ === xdomain.timeout / CHECK_INTERVAL) {
+      if (checks++ >= xdomain.timeout / CHECK_INTERVAL) {
         warn("Timeout waiting on iframe socket");
+        emitter.fire("timeout");
+        sock.fire("abort");
       } else {
         setTimeout(check, CHECK_INTERVAL);
       }
@@ -928,16 +968,27 @@ slice = function(o, n) {
 
 console = window.console || {};
 
+emitter = null;
+
+setupEmitter = function() {
+  emitter = xhook.EventEmitter(true);
+  xdomain.on = emitter.on;
+};
+
+if (xhook) {
+  setupEmitter();
+}
+
 logger = function(type) {
   return function(str) {
     str = "xdomain (" + currentOrigin + "): " + str;
-    if (type in xdomain) {
-      xdomain[type](str);
-    }
+    emitter.fire(type, str);
     if (type === 'log' && !xdomain.debug) {
       return;
     }
-    if (type in console) {
+    if (type in xdomain) {
+      xdomain[type](str);
+    } else if (type in console) {
       console[type](str);
     } else if (type === 'warn') {
       alert(str);
@@ -1069,9 +1120,11 @@ startPostMessage();
 if (typeof this.define === "function" && this.define.amd) {
   define("xdomain", ["xhook"], function(xh) {
     xhook = xh;
+    setupEmitter();
     return xdomain;
   });
 } else {
   (this.exports || this).xdomain = xdomain;
 }
+
 }.call(this,window));


### PR DESCRIPTION
...uch as timeouts.  For example `xdomain.on("timeout", handler)` See https://github.com/jpillora/xdomain/issues/102 
